### PR TITLE
Change order of cloudbuild steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,12 +4,12 @@ steps:
   args: ['get', '-t', './...']
   env: ['PROJECT_ROOT=go-in-go']
 
-- id: 'Run Test Suite'
-  name: 'gcr.io/cloud-builders/go'
-  args: ['test']
-  env: ['PROJECT_ROOT=go-in-go']
-
-- id: 'Install Binary'
+- id: 'Build'
   name: 'gcr.io/cloud-builders/go'
   args: ['install','.']
+  env: ['PROJECT_ROOT=go-in-go']
+
+- id: 'Run Tests'
+  name: 'gcr.io/cloud-builders/go'
+  args: ['test']
   env: ['PROJECT_ROOT=go-in-go']


### PR DESCRIPTION
I think it makes slightly more sense to `go install` and then run `go test`